### PR TITLE
Change speedx method to RT data stream EXAMPLE

### DIFF
--- a/urx/urrobot.py
+++ b/urx/urrobot.py
@@ -86,6 +86,15 @@ class URRobot(object):
         self.logger.info("Sending program: " + prog)
         self.secmon.send_program(prog)
 
+    def send_custom_program(self, prog):
+        """
+        send a complete program using urscript to the robot
+        the program is executed immediatly and any runnning
+        program is interrupted
+        """
+        self.logger.info("Sending program: " + prog)
+        self.rtmon.send_program(prog)
+
     def get_tcp_force(self, wait=True):
         """
         return measured force in TCP
@@ -264,7 +273,7 @@ class URRobot(object):
         vels.append(acc)
         vels.append(min_time)
         prog = "{}([{},{},{},{},{},{}], a={}, t_min={})".format(command, *vels)
-        self.send_program(prog)
+        self.send_custom_program(prog)
 
     def movej(self, joints, acc=0.1, vel=0.05, wait=True, relative=False, threshold=None):
         """


### PR DESCRIPTION
This is an example pull request to show how it is possible to change robot commands to the real-time data stream. This is quite useful if you want to control the robot in any real-time manner. (For example direct speed control, or velocity control using PID... Etc.)

It allows the URscript to be sent at 125Hz or more, according to this webpage: https://www.universal-robots.com/how-tos-and-faqs/how-to/ur-how-tos/remote-control-via-tcpip-16496/

For now only the speedx method is converted to the RT stream, but converting all other movement methods should be analogous. 