### PR TITLE
Hotfix für #73: remove explicit min_t parameter

### DIFF
--- a/urx/urrobot.py
+++ b/urx/urrobot.py
@@ -263,7 +263,7 @@ class URRobot(object):
         vels = [round(i, self.max_float_length) for i in velocities]
         vels.append(acc)
         vels.append(min_time)
-        prog = "{}([{},{},{},{},{},{}], a={}, t_min={})".format(command, *vels)
+        prog = "{}([{},{},{},{},{},{}], a={}, t={})".format(command, *vels)
         self.send_program(prog)
 
     def movej(self, joints, acc=0.1, vel=0.05, wait=True, relative=False, threshold=None):

--- a/urx/urrobot.py
+++ b/urx/urrobot.py
@@ -263,7 +263,7 @@ class URRobot(object):
         vels = [round(i, self.max_float_length) for i in velocities]
         vels.append(acc)
         vels.append(min_time)
-        prog = "{}([{},{},{},{},{},{}], a={}, t={})".format(command, *vels)
+        prog = "{}([{},{},{},{},{},{}], {}, {})".format(command, *vels)
         self.send_program(prog)
 
     def movej(self, joints, acc=0.1, vel=0.05, wait=True, relative=False, threshold=None):


### PR DESCRIPTION
see https://github.com/SintefManufacturing/python-urx/issues/73#issuecomment-555387672 for the hotfix. 

This might limit usage to UR >= 3.5. A check for the version should be added, but needs a little more work. 

